### PR TITLE
Adding Python3 compatibility

### DIFF
--- a/hid.pyx
+++ b/hid.pyx
@@ -54,7 +54,7 @@ cdef class device:
 
   def write(self, buff):
       '''Accept a list of integers (0-255) and send them to the device'''
-      buff = ''.join(map(chr, buff)) # convert to bytes
+      buff = bytes(buff) # convert to bytes
       cdef unsigned char* cbuff = buff # covert to c string
       return hid_write(self._c_hid, cbuff, len(buff))
 
@@ -101,7 +101,7 @@ cdef class device:
 
   def send_feature_report(self, buff):
       '''Accept a list of integers (0-255) and send them to the device'''
-      buff = ''.join(map(chr, buff)) # convert to bytes
+      buff = bytes(buff) # convert to bytes
       cdef unsigned char* cbuff = buff # covert to c string
       return hid_send_feature_report(self._c_hid, cbuff, len(buff))
 


### PR DESCRIPTION
Hi!
I was using hidapi together with Python3.3.5.
To get it working I had to convert the _list of ints_ to _bytes_ instead of to a _str_.
Not sure if the entire module is now Python3 compatible though.

The question is also how to keep compatibility with Python2. Any ideas?

Best, Philipp
