### PR TITLE
Bug fix and releasing GIL during I/O

### DIFF
--- a/chid.pxd
+++ b/chid.pxd
@@ -20,15 +20,15 @@ cdef extern from "hidapi.h":
   hid_device_info* hid_enumerate(unsigned short, unsigned short)
   void hid_free_enumeration(hid_device_info*)
 
-  hid_device* hid_open(unsigned short, unsigned short, void*)
+  hid_device* hid_open(unsigned short, unsigned short, const wchar_t*)
   hid_device* hid_open_path(char *path)
   void hid_close(hid_device *)
-  int hid_write(hid_device* device, unsigned char *data, int length)
-  int hid_read(hid_device* device, unsigned char* data, int max_length)
-  int hid_read_timeout(hid_device* device, unsigned char* data, int max_length, int milliseconds)
+  int hid_write(hid_device* device, unsigned char *data, int length) nogil
+  int hid_read(hid_device* device, unsigned char* data, int max_length) nogil
+  int hid_read_timeout(hid_device* device, unsigned char* data, int max_length, int milliseconds) nogil
   int hid_set_nonblocking(hid_device* device, int value)
-  int hid_send_feature_report(hid_device* device, unsigned char *data, int length)
-  int hid_get_feature_report(hid_device* device, unsigned char *data, int length)
+  int hid_send_feature_report(hid_device* device, unsigned char *data, int length) nogil
+  int hid_get_feature_report(hid_device* device, unsigned char *data, int length) nogil
 
   int hid_get_manufacturer_string(hid_device*, wchar_t *, size_t)
   int hid_get_product_string(hid_device*, wchar_t *, size_t)

--- a/hid.pyx
+++ b/hid.pyx
@@ -62,8 +62,13 @@ cdef class device:
           buff = ''.join(map(chr, buff))
       else:
           buff = bytes(buff)
+      cdef hid_device * c_hid = self._c_hid
       cdef unsigned char* cbuff = buff # covert to c string
-      return hid_write(self._c_hid, cbuff, len(buff))
+      cdef size_t c_buff_len = len(buff)
+      cdef int result
+      with nogil:
+        result = hid_write(c_hid, cbuff, c_buff_len)
+      return result
 
   def set_nonblocking(self, v):
       '''Set the nonblocking flag'''
@@ -73,14 +78,19 @@ cdef class device:
       '''Return a list of integers (0-255) from the device up to max_length bytes.'''
       cdef unsigned char lbuff[16]
       cdef unsigned char* cbuff
+      cdef size_t c_max_length = max_length
+      cdef int c_timeout_ms = timeout_ms
+      cdef hid_device * c_hid = self._c_hid
       if max_length <= 16:
           cbuff = lbuff
       else:
           cbuff = <unsigned char *>malloc(max_length)
       if timeout_ms > 0:
-          n = hid_read_timeout(self._c_hid, cbuff, max_length, timeout_ms)
+        with nogil:
+            n = hid_read_timeout(c_hid, cbuff, c_max_length, c_timeout_ms)
       else:
-          n = hid_read(self._c_hid, cbuff, max_length)
+        with nogil:
+            n = hid_read(c_hid, cbuff, c_max_length)
       res = []
       for i in range(n):
           res.append(cbuff[i])
@@ -113,18 +123,27 @@ cdef class device:
           buff = ''.join(map(chr, buff))
       else:
           buff = bytes(buff)
+      cdef hid_device * c_hid = self._c_hid
       cdef unsigned char* cbuff = buff # covert to c string
-      return hid_send_feature_report(self._c_hid, cbuff, len(buff))
+      cdef size_t c_buff_len = len(buff)
+      cdef int result
+      with nogil:
+        result = hid_send_feature_report(c_hid, cbuff, c_buff_len)
+      return result
 
   def get_feature_report(self, report_num, max_length):
+      cdef hid_device * c_hid = self._c_hid
       cdef unsigned char lbuff[16]
       cdef unsigned char* cbuff
+      cdef size_t c_max_length = max_length
+      cdef int n
       if max_length <= 16:
           cbuff = lbuff
       else:
           cbuff = <unsigned char *>malloc(max_length)
       cbuff[0] = report_num
-      n = hid_get_feature_report(self._c_hid, cbuff, max_length)
+      with nogil:
+        n = hid_get_feature_report(c_hid, cbuff, c_max_length)
       res = []
       for i in range(n):
           res.append(cbuff[i])


### PR DESCRIPTION
- Fixed issue where manufacturer and product strings were incorrectly decoded on OS X (not sure about other OSes). There was a 0 byte inserted between every character, like the wrong char size was used. Fix tested on OS X 10.10 and Windows 7.
- The GIL is released during read(), write(), set_feature_report(), and get_feature_report() calls. This makes it possible to improve performance by moving HID I/O to a separate thread.
- Also made VID and PID parameters on enumerate() optional, to make it more natural to get a list of all HID devices.
