### PR TITLE
Handle cases where the HID device is closed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ if sys.platform.startswith('win'):
 
 setup(
     name = 'hidapi',
-    version = '0.7.99-8',
+    version = '0.7.99-9',
     description = 'A Cython interface to the hidapi from https://github.com/signal11/hidapi',
     author = 'Gary Bishop',
     author_email = 'gb@cs.unc.edu',


### PR DESCRIPTION
- detect when exceptions cause the HID device not to be open after call to device.open() (ie. bad serial number)
- check the HID device is actually open before each call that uses self._c_hid

... so we don't have segfaults inside HID library which bring down the entire python world.

I'm obviously smoothing some rough edges that I cut myself on today. No API change just robustness.