### PR TITLE
Add --without-libusb option to setup.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,10 @@ install:
     - pip install "pip>=7.0" wheel
     - pip install -r requirements.txt
 
+env:
+    - EXTRAOPTION=
+    - EXTRAOPTION=--without-libusb
+
 script:
-    - python setup.py install
+    - python setup.py install $EXTRAOPTION
     - python tests.py

--- a/README.rst
+++ b/README.rst
@@ -24,7 +24,7 @@ Software Dependencies
 
 * Python (http://python.org/download/)
 * Cython (http://cython.org/#download)
-* libusb and libudev on Linux
+* hidraw or libusb and libudev on Linux
 
 License
 -------
@@ -54,6 +54,10 @@ Build from source
 3. Build cython-hidapi extension module::
 
     $ python setup.py build
+
+   To use hidraw API instead of libusb add --without-libusb option::
+
+    $ python setup.py build --without-libusb
 
 4. Install cython-hidapi module into your Python distribution::
 

--- a/setup.py
+++ b/setup.py
@@ -19,18 +19,26 @@ except ImportError:
     pass
 
 if sys.platform.startswith('linux'):
-    modules = [
-        Extension('hid',
-                  sources = ['hid.pyx', 'chid.pxd', hidapi_src('libusb')],
-                  include_dirs = [hidapi_include, '/usr/include/libusb-1.0'],
-                  libraries = ['usb-1.0', 'udev', 'rt'],
-        ),
-        Extension('hidraw',
+    modules = []
+    if '--without-libusb' in sys.argv:
+        sys.argv.remove('--without-libusb')
+        hidraw_module = 'hid'
+    else:
+        hidraw_module = 'hidraw'
+        modules.append(
+            Extension('hid',
+                      sources = ['hid.pyx', 'chid.pxd', hidapi_src('libusb')],
+                      include_dirs = [hidapi_include, '/usr/include/libusb-1.0'],
+                      libraries = ['usb-1.0', 'udev', 'rt'],
+            )
+        )
+    modules.append(
+        Extension(hidraw_module,
                   sources = ['hidraw.pyx', hidapi_src('linux')],
                   include_dirs = [hidapi_include],
                   libraries = ['udev', 'rt'],
         )
-    ]
+    )
 
 if sys.platform.startswith('darwin'):
     os.environ['CFLAGS'] = '-framework IOKit -framework CoreFoundation'


### PR DESCRIPTION
This option allows to build and install cython-hidapi
with hidraw support only on Linux. Thus libusb dependency
becomes optional.

Because there is no standard support in setuptools for
--with-<feature>/--without-<feature> options during building
we choose the simplest solution suggest at [1].

Also we change the hidraw extension module name from 'hidraw'
to 'hid' in case --without-libusb is specified.
This is required to keep external cython-hidapi API consistent
and not to bother user with backend chosen.

[1] - http://stackoverflow.com/questions/677577/distutils-how-to-pass-a-user-defined-parameter-to-setup-py

fixes #9 