### PR TITLE
Raise IOError on device read() failure

### DIFF
--- a/hid.pyx
+++ b/hid.pyx
@@ -118,6 +118,8 @@ cdef class device:
       else:
         with nogil:
             n = hid_read(c_hid, cbuff, c_max_length)
+      if n is -1:
+          raise IOError('read error')
       res = []
       for i in range(n):
           res.append(cbuff[i])


### PR DESCRIPTION
Right now, there's no real difference between a failed read and an empty read when polling with "device.read()". 

hidapi already handles this case by returning n of -1 (different from n of 0), but since we populate an array, the array stays empty. And there's no difference for the programmer between an empty read and a failed read. The main use case for this is to tell when the machine has been disconnected.

Unfortunately, this is a breaking change → people working off of the length of the result will get an exception when the response is -1. The other solution I was thinking of was just returning n as a second return value, but that's not backwards compatible either, because then the function would return a tuple.

I tested this on OS X only. I can test on Windows if you'd like, as well.