### PR TITLE
fix serial number type

### DIFF
--- a/hid.pyx
+++ b/hid.pyx
@@ -44,7 +44,7 @@ def enumerate(int vendor_id=0, int product_id=0):
 cdef class device:
   cdef hid_device *_c_hid
 
-  def open(self, int vendor_id=0, int product_id=0, bytes serial_number=None):
+  def open(self, int vendor_id=0, int product_id=0, unicode serial_number=None):
       cdef wchar_t * cserial_number = NULL
       cdef int serial_len
       cdef Py_ssize_t result


### PR DESCRIPTION

Currently, device.open() is an error when the serial_number argument is used.
```python
device.open(0x1941, 0x8021, serial_number=u'0000134865')
# python 2:
# TypeError: Argument 'serial_number' has incorrect type (expected str, got unicode)
# python 3:
# TypeError: Argument 'serial_number' has incorrect type (expected bytes, got str)

device.open(0x1941, 0x8021, serial_number=b'0000134865')
# python 2:
# IOError: open failed
# python 3:
# ValueError: invalid serial number string
```

[PyUnicode_AsWideChar](https://docs.python.org/3.5/c-api/unicode.html#c.PyUnicode_AsWideChar)
is meant to take a unicode object. When it gets a bytes object, it returns (-1).

This commit changes the type of serial_number to unicode. Now open() works just fine.

Tested on Windows, python 2.7 and python 3.5
