### PR TITLE
setup: remove Cython from install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -95,6 +95,6 @@ setup(
     ],
     ext_modules = modules,
     setup_requires = ['Cython'],
-    install_requires = ['Cython'],
+    install_requires = [],
     **setup_args
 )


### PR DESCRIPTION
It's only needed at build time.