### PR TITLE
enable build against hidapi installed on system

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,3 +3,4 @@ include hidapi/libusb/hid.c
 include hidapi/linux/hid.c
 include hidapi/mac/hid.c
 include hidapi/windows/hid.c
+include LICENSE*.txt

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,3 +5,4 @@ include hidapi/mac/hid.c
 include hidapi/windows/hid.c
 include LICENSE*.txt
 include tests.py
+include try.py

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,3 +4,4 @@ include hidapi/linux/hid.c
 include hidapi/mac/hid.c
 include hidapi/windows/hid.c
 include LICENSE*.txt
+include tests.py

--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,7 @@ if 'bsd' in sys.platform:
 
 setup(
     name = 'hidapi',
-    version = '0.7.99.post19',
+    version = '0.7.99.post20',
     description = 'A Cython interface to the hidapi from https://github.com/signal11/hidapi',
     author = 'Gary Bishop',
     author_email = 'gb@cs.unc.edu',

--- a/setup.py
+++ b/setup.py
@@ -116,6 +116,7 @@ setup(
         'Programming Language :: Python :: 3.2',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
     ],
     ext_modules = modules,
     setup_requires = ['Cython'],


### PR DESCRIPTION
Hi,

I just packaged cython-hidapi for Fedora and RHEL7.  As part of my packaging work, I tried to build against the system's hidapi-library, thus I added a switch to setup.py and adjusted the manifest to pick up some useful files into the PyPi-tarball, which need to be included in Fedora's RPM.