### PR TITLE
build hidraw.so from hidraw.pyx

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ if sys.platform.startswith('linux'):
             )
         )
     libs = ['udev', 'rt']
-    src = ['hid.pyx', 'chid.pxd']
+    src = ['hidraw.pyx', 'chid.pxd']
     if system_hidapi == 1:
         libs.append('hidapi-hidraw')
     else:


### PR DESCRIPTION
when hidraw.so is compiled from hid.pyx it has module-init function `inithid` instead if `inithidraw`