### PR TITLE
Add call to hid_exit() in close()

### DIFF
--- a/chid.pxd
+++ b/chid.pxd
@@ -19,6 +19,7 @@ cdef extern from "hidapi.h":
 
   hid_device_info* hid_enumerate(unsigned short, unsigned short)
   void hid_free_enumeration(hid_device_info*)
+  int hid_exit()
 
   hid_device* hid_open(unsigned short, unsigned short, const wchar_t*)
   hid_device* hid_open_path(char *path)

--- a/hid.pyx
+++ b/hid.pyx
@@ -75,6 +75,7 @@ cdef class device:
       if self._c_hid != NULL:
           hid_close(self._c_hid)
           self._c_hid = NULL
+          hid_exit()
 
   def write(self, buff):
       '''Accept a list of integers (0-255) and send them to the device'''


### PR DESCRIPTION
Without calling hid_exit() in close(), hid_enumerate() can segfault when called by multiple threads even if they are synchronized. It's also needed to prevent memory leaks.