### PR TITLE
IOError thrown when get feature report fails

### DIFF
--- a/hid.pyx
+++ b/hid.pyx
@@ -185,6 +185,8 @@ cdef class device:
       with nogil:
         n = hid_get_feature_report(c_hid, cbuff, c_max_length)
       res = []
+      if n is -1:
+          raise IOError('read error')
       for i in range(n):
           res.append(cbuff[i])
       if max_length > 16:

--- a/hid.pyx
+++ b/hid.pyx
@@ -185,7 +185,7 @@ cdef class device:
       with nogil:
         n = hid_get_feature_report(c_hid, cbuff, c_max_length)
       res = []
-      if n is -1:
+      if n < 0:
           raise IOError('read error')
       for i in range(n):
           res.append(cbuff[i])


### PR DESCRIPTION
## Overview
Addresses [Issue 56](https://github.com/trezor/cython-hidapi/issues/56) - Ensures that errors encountered by the underlying hidapi library on `get_feature_report` are passed up through the cython wrapper.

## Testing
I verified that the test case where I first observed this throws an error with the change introduced here.
