### PR TITLE
IOError raised when get manufact, sn and product strings fails

### DIFF
--- a/hid.pyx
+++ b/hid.pyx
@@ -133,24 +133,28 @@ cdef class device:
           raise ValueError('not open')
       cdef wchar_t buff[255]
       cdef int r = hid_get_manufacturer_string(self._c_hid, buff, 255)
-      if not r:
-          return U(buff)
+      if r == -1:
+          raise IOError('get manufacturer string error')
+      return U(buff)
+      
 
   def get_product_string(self):
       if self._c_hid == NULL:
           raise ValueError('not open')
       cdef wchar_t buff[255]
       cdef int r = hid_get_product_string(self._c_hid, buff, 255)
-      if not r:
-          return U(buff)
+      if r == -1:
+          raise IOError('get product string error')
+      return U(buff)
 
   def get_serial_number_string(self):
       if self._c_hid == NULL:
           raise ValueError('not open')
       cdef wchar_t buff[255]
       cdef int r = hid_get_serial_number_string(self._c_hid, buff, 255)
-      if not r:
-          return U(buff)
+      if r == -1:
+          raise IOError('get serial number string error')
+      return U(buff)
 
   def send_feature_report(self, buff):
       if self._c_hid == NULL:

--- a/hid.pyx
+++ b/hid.pyx
@@ -133,17 +133,17 @@ cdef class device:
           raise ValueError('not open')
       cdef wchar_t buff[255]
       cdef int r = hid_get_manufacturer_string(self._c_hid, buff, 255)
-      if r == -1:
+      if r < 0:
           raise IOError('get manufacturer string error')
       return U(buff)
-      
+
 
   def get_product_string(self):
       if self._c_hid == NULL:
           raise ValueError('not open')
       cdef wchar_t buff[255]
       cdef int r = hid_get_product_string(self._c_hid, buff, 255)
-      if r == -1:
+      if r < 0:
           raise IOError('get product string error')
       return U(buff)
 
@@ -152,7 +152,7 @@ cdef class device:
           raise ValueError('not open')
       cdef wchar_t buff[255]
       cdef int r = hid_get_serial_number_string(self._c_hid, buff, 255)
-      if r == -1:
+      if r < 0:
           raise IOError('get serial number string error')
       return U(buff)
 


### PR DESCRIPTION
All getters above return `-1` if fails according
to HIPAPI lib docs. So `IOError` is raised every
time the getter fails.

Fix #61 