### PR TITLE
Switch to libusb branch of hidapi

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "hidapi"]
 	path = hidapi
-	url = https://github.com/signal11/hidapi.git
+	url = https://github.com/libusb/hidapi.git

--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ cython-hidapi
 Description
 -----------
 
-A Cython interface to `HIDAPI <https://github.com/signal11/hidapi>`_ library.
+A Cython interface to `HIDAPI <https://github.com/libusb/hidapi>`_ library.
 
 This has been tested with:
 

--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,7 @@ if 'bsd' in sys.platform:
 setup(
     name = 'hidapi',
     version = '0.7.99.post21',
-    description = 'A Cython interface to the hidapi from https://github.com/signal11/hidapi',
+    description = 'A Cython interface to the hidapi from https://github.com/libusb/hidapi',
     author = 'Gary Bishop',
     author_email = 'gb@cs.unc.edu',
     maintainer = 'Pavol Rusnak',


### PR DESCRIPTION
Per https://github.com/signal11/hidapi/issues/373#issuecomment-498836983, this switches to the `libusb` branch of `hidapi`, as signal11's original branch is no longer maintained.

This pins to the `hidapi-v0.9.0` tag.