### PR TITLE
setup.py: Add /usr/local/ prefix to include dirs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,10 @@ if 'bsd' in sys.platform:
         include_dirs_bsd = ['/usr/local/include/hidapi']
     else:
         libs = ['usb-1.0']
-        include_dirs_bsd = [hidapi_include, '/usr/include/libusb-1.0']
+        include_dirs_bsd = [hidapi_include,
+                            '/usr/include/libusb-1.0',
+                            '/usr/local/include/libusb-1.0',
+                            '/usr/local/include/']
         if system_hidapi == True:
             libs.append('hidapi-libusb')
         else:


### PR DESCRIPTION
Some *nix operating systems (such as *BSD) store 3rd party libraries along with
their headers in the /usr/local/ prefix instead of /usr/.