### PR TITLE
WIP: Fix build issues on AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -75,7 +75,7 @@ install:
 
   # Upgrade to the latest version of pip to avoid it displaying warnings
   # about it being out of date.
-  - "pip install --disable-pip-version-check --user --upgrade pip"
+  - "python -m pip install --disable-pip-version-check --user --upgrade pip"
 
   # Install twine, support for 'bdist_wheel' and update setuptools.
   - "pip install --upgrade wheel setuptools twine"


### PR DESCRIPTION
(Try to) fix the issues with the AppVeyor builds:

 - [ ] Error with MSVC/C89: `error C2275: 'BOOL' : illegal use of this type as an expression`
 - [x] Upgrading pip in-place fails with: `ERROR: To modify pip, please run the following [...]`