### PR TITLE
added support for the "get_input_report" function

### DIFF
--- a/chid.pxd
+++ b/chid.pxd
@@ -29,6 +29,7 @@ cdef extern from "hidapi.h":
   int hid_set_nonblocking(hid_device* device, int value)
   int hid_send_feature_report(hid_device* device, unsigned char *data, int length) nogil
   int hid_get_feature_report(hid_device* device, unsigned char *data, int length) nogil
+  int hid_get_input_report(hid_device* device, unsigned char *data, int length) nogil
 
   int hid_get_manufacturer_string(hid_device*, wchar_t *, size_t)
   int hid_get_product_string(hid_device*, wchar_t *, size_t)

--- a/hid.pyx
+++ b/hid.pyx
@@ -206,6 +206,30 @@ cdef class device:
           free(cbuff)
       return res
 
+  def get_input_report(self, int report_num, int max_length):
+      if self._c_hid == NULL:
+          raise ValueError('not open')
+      cdef hid_device * c_hid = self._c_hid
+      cdef unsigned char lbuff[16]
+      cdef unsigned char* cbuff
+      cdef size_t c_max_length = max_length
+      cdef int n
+      if max_length <= 16:
+          cbuff = lbuff
+      else:
+          cbuff = <unsigned char *>malloc(max_length)
+      cbuff[0] = report_num
+      with nogil:
+          n = hid_get_input_report(c_hid, cbuff, c_max_length)
+      res = []
+      if n < 0:
+          raise IOError('read error')
+      for i in range(n):
+          res.append(cbuff[i])
+      if max_length > 16:
+          free(cbuff)
+      return res
+
   def error(self):
       if self._c_hid == NULL:
           raise ValueError('not open')


### PR DESCRIPTION
* stole the implementation of the "get_feature_report" function and used it to define the "get_input_report" function in the hid.pyx file
* added the "hid_get_input_report" singature in the chid.pxd file

Here's how I tested this:
```python
import hid
d = hid.device()
d.open_path(b'IOService:/AppleACPIPlatformExpert/PCI0@0/AppleACPIPCI/XHC1@14/XHC1@14000000/HS02@14200000/Microsoft Pro Intellimouse@14200000/HID KEYBOARD DEVICE@1/AppleUserUSBHostHIDDevice')

# change led color
d.send_feature_report([0x24,0xB2,0x03,0xFF,0x00,0x00] + [0x00] * 67)
# read led color
d.send_feature_report([0x24,0xB3] + [0x00] * 71)
d.get_input_report(0x27, 0x29)
```
this should fix #87
