### PR TITLE
call hid_enumerate() without gil

### DIFF
--- a/chid.pxd
+++ b/chid.pxd
@@ -17,7 +17,7 @@ cdef extern from "hidapi.h":
     int interface_number
     hid_device_info *next
 
-  hid_device_info* hid_enumerate(unsigned short, unsigned short)
+  hid_device_info* hid_enumerate(unsigned short, unsigned short) nogil
   void hid_free_enumeration(hid_device_info*)
 
   hid_device* hid_open(unsigned short, unsigned short, const wchar_t*)

--- a/hid.pyx
+++ b/hid.pyx
@@ -21,7 +21,9 @@ cdef object U(wchar_t *wcs):
   return PyUnicode_FromWideChar(wcs, n)
 
 def enumerate(int vendor_id=0, int product_id=0):
-  cdef hid_device_info* info = hid_enumerate(vendor_id, product_id)
+  cdef hid_device_info* info
+  with nogil:
+    info = hid_enumerate(vendor_id, product_id)
   cdef hid_device_info* c = info
   res = []
   while c:


### PR DESCRIPTION
At least on linux, while plugging in a faulty hid device, the usb
subsystem tries to enumerate the new device for some time before giving
up. hid_enumerate() will then also block.
this is very unfortunate if a gui thread continuously polls for new
devices. calling hid_enumerate() with the gil released solves this
issue.

Signed-off-by: Martin Gysel <me@bearsh.org>