### PR TITLE
Added apt install instructions for readthedocs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,6 +5,11 @@
 # Required
 version: 2
 
+build:
+  apt_packages:
+    - libusb-1.0.0-dev
+    - libudev-dev
+
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
    configuration: docs/conf.py
@@ -24,7 +29,3 @@ python:
    - requirements: docs/requirements.txt
    - method: setuptools
      path: .
-
-#
-# Build on ReadTheDocs is not working because libusb and libudev are missing.
-#


### PR DESCRIPTION
In the last monts ReadTheDocs pushed an update so you can install apt packages before building, so now hidapi's documentation could be built there automatically.
See #106 for the full story.

Example build on RTD can be found here: https://roberto-hidapi.readthedocs.io/en/feature-docs/