### PR TITLE
Remove references to self when creating device finalizers

### DIFF
--- a/hid.pyx
+++ b/hid.pyx
@@ -98,6 +98,8 @@ cdef class device:
         cdef wchar_t * cserial_number = NULL
         cdef int serial_len
         cdef Py_ssize_t result
+        if self._c_hid != NULL:
+            raise RuntimeError('already open')
         try:
             if serial_number is not None:
                 serial_len = len(serial_number)
@@ -123,6 +125,8 @@ cdef class device:
         :raises IOError:
         """
         cdef char* cbuff = path
+        if self._c_hid != NULL:
+            raise RuntimeError('already open')
         self._c_hid = hid_open_path(cbuff)
         if self._c_hid == NULL:
             raise IOError('open failed')


### PR DESCRIPTION
Reported-by @bearsh in https://github.com/trezor/cython-hidapi/pull/130#discussion_r741972793.

---

From the documentation:

> It is important to ensure that `func`, `args` and `kwargs` do not own any references to `obj`, either directly or indirectly, since otherwise `obj` will never be garbage collected. In particular, `func` should not be a bound method of `obj`.

The issue wasn't observed during testing, but it may be implementation-defined (as with `__del__`) and depend on specific
combinations of interpreter and Cython versions.

Instead of relying on unspecified behavior, only keep the `hid_device` pointer.  This requires a wrapper because `weakref.finalize()` cannot be passed `cdef` functions or C pointers.

Alternatives were attempted—`__dealloc__`, `weakref.ref(self)`—but they only worked in some cases (respectively: only for `del <device>` and except for `del <device>`).

Besides removing references to `self` from the finalizers, also fix another problem in #130: raise a `RuntimeError` if `open()`/`open_path()` are called on an already open `device()`, preventing the old `hid_device *` to leak, which would later crash `hid_exit()`. 