### PR TITLE
expose version of bindings as `hid.__version__`

### DIFF
--- a/hid.pyx
+++ b/hid.pyx
@@ -4,6 +4,10 @@ import weakref
 from chid cimport *
 from libc.stddef cimport wchar_t, size_t
 
+
+__version__ = "0.12.0.post2"
+
+
 cdef extern from "ctype.h":
     int wcslen(wchar_t*)
 

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@ from setuptools import setup, Extension
 import os
 import sys
 import subprocess
+import re
 
 hidapi_topdir = os.path.join("hidapi")
 hidapi_include = os.path.join(hidapi_topdir, "hidapi")
@@ -99,9 +100,21 @@ if "bsd" in sys.platform:
         Extension("hid", sources=src, include_dirs=include_dirs_bsd, libraries=libs,)
     ]
 
+
+def find_version():
+    tld = os.path.abspath(os.path.dirname(__file__))
+    filename = os.path.join(tld, 'hid.pyx')
+    with open(filename) as f:
+        text = f.read()
+    match = re.search(r"^__version__ = \"(.*)\"$", text, re.MULTILINE)
+    if not match:
+        raise RuntimeError('cannot find version')
+    return match.group(1)
+
+
 setup(
     name="hidapi",
-    version="0.12.0.post2",
+    version=find_version(),
     description="A Cython interface to the hidapi from https://github.com/libusb/hidapi",
     long_description=open("README.rst", "rt").read(),
     author="Pavol Rusnak",


### PR DESCRIPTION
I believe it is good practice to expose the version of python libraries at runtime in the top-level `__version__` attribute.
Depending on how the package was installed, it might be possible to grab the version setup.py used during installation, using importlib, but this is not always the case.

For reference:
```python
>>> import hid
>>> ver1 = hid.__version__
>>>
>>> from importlib.metadata import version
>>> try:
...     ver2 = version("hidapi")
... except ImportError:
...     ver2 = None
...
>>> print(f"{ver1!r}, {ver2!r}")
'0.12.0.post2', '0.12.0.post2'
```