### PR TITLE
expose hid_version_str

### DIFF
--- a/chid.pxd
+++ b/chid.pxd
@@ -37,3 +37,4 @@ cdef extern from "hidapi.h":
     int hid_get_serial_number_string(hid_device*, wchar_t *, size_t)
     int hid_get_indexed_string(hid_device*, int, wchar_t *, size_t)
     wchar_t *hid_error(hid_device *)
+    char* hid_version_str()

--- a/hid.pyx
+++ b/hid.pyx
@@ -66,6 +66,14 @@ def enumerate(int vendor_id=0, int product_id=0):
     hid_free_enumeration(info)
     return res
 
+def version_str():
+    """Return a runtime version string of the hidapi C library.
+
+    :return: version string of library
+    :rtype: str
+    """
+    return (<bytes>hid_version_str()).decode('ascii')
+
 cdef class _closer:
     """Wrap a hid_device *ptr and a provide a way to call hid_close() on it.
 


### PR DESCRIPTION
`hid_version_str` was added to the underlying C library in 0.10.0, in https://github.com/libusb/hidapi/pull/192

Note that the method added here returns the version of the C library,
which is different from the version of cython-hidapi, i.e. the `hid` python package.
It would be good to also make the latter available at runtime (for that, see https://github.com/trezor/cython-hidapi/pull/143 ).

For reference:
```python
>>> import hid
>>> ver1 = hid.version_str()
>>> 
>>> from importlib.metadata import version
>>> try:
...     ver2 = version("hidapi")
... except ImportError:
...     ver2 = None
... 
>>> print(f"{ver1!r}, {ver2!r}")
'0.12.0', '0.12.0.post2'
```