### PR TITLE
Update cibuildwheel action to 2.11.2

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -26,7 +26,7 @@ jobs:
         uses: docker/setup-qemu-action@v1
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.3.1
+        uses: pypa/cibuildwheel@v2.11.2
         env:
           CIBW_BUILD: "cp3*-*"
           CIBW_SKIP: "*-musllinux_*"


### PR DESCRIPTION
This should enable the building of wheels for Python 3.11.

Assuming everything goes well here, please upload the Python 3.11 wheels to PyPI when you have some time.

---

In the future, we might want to consider just specifying the major version number, as the cibuildwheel action is probably something we always want to run the latest available (as long as it doesn't do any breaking changes).

