### PR TITLE
Call `hid_init()` at import time, to avoid macOS crash

### DIFF
--- a/chid.pxd
+++ b/chid.pxd
@@ -23,6 +23,7 @@ cdef extern from "hidapi.h":
     hid_device* hid_open(unsigned short, unsigned short, const wchar_t*)
     hid_device* hid_open_path(char *path)
     void hid_close(hid_device *)
+    int hid_init()
     int hid_exit()
     int hid_write(hid_device* device, unsigned char *data, int length) nogil
     int hid_read(hid_device* device, unsigned char* data, int max_length) nogil

--- a/hid.pyx
+++ b/hid.pyx
@@ -8,6 +8,9 @@ from libc.stddef cimport wchar_t, size_t
 __version__ = "0.13.1"
 
 
+hid_init()
+
+
 cdef extern from "ctype.h":
     int wcslen(wchar_t*)
 


### PR DESCRIPTION
fixes https://github.com/trezor/cython-hidapi/issues/142
fixes https://github.com/trezor/cython-hidapi/issues/148

note https://github.com/trezor/cython-hidapi/issues/148#issuecomment-1542302679 :
> HIDAPI on macOS has an additional issue regarding thread-safety.
> I did encountered it in my project(s) but didn't have enough time to gather info/find a root cause.
> Looks like on macOS hid_init/hid_exit needs to be called in the same thread,
> which is an additional restriction compared to other platforms.

-----

I have tested on macOS 12.5 (amd64), where using the reproducers in the opening posts of https://github.com/trezor/cython-hidapi/issues/142 and https://github.com/trezor/cython-hidapi/issues/148, I can reproduce a SIGILL (without this patch).
With this patch, there is no SIGILL anymore, the sample scripts work as expected.