### PR TITLE
Exposing bus_type field from hid_device_info.

### DIFF
--- a/chid.pxd
+++ b/chid.pxd
@@ -4,6 +4,13 @@ cdef extern from "hidapi.h":
     ctypedef struct hid_device:
         pass
 
+    cdef enum hid_bus_type:
+        HID_API_BUS_UNKNOWN = 0x00,
+        HID_API_BUS_USB = 0x01,
+        HID_API_BUS_BLUETOOTH = 0x02,
+        HID_API_BUS_I2C = 0x03,
+        HID_API_BUS_SPI = 0x04
+
     cdef struct hid_device_info:
         char *path
         unsigned short vendor_id
@@ -16,6 +23,7 @@ cdef extern from "hidapi.h":
         unsigned short usage
         int interface_number
         hid_device_info *next
+        hid_bus_type bus_type
 
     hid_device_info* hid_enumerate(unsigned short, unsigned short) nogil
     void hid_free_enumeration(hid_device_info*)

--- a/hid.pyx
+++ b/hid.pyx
@@ -5,7 +5,7 @@ from chid cimport *
 from libc.stddef cimport wchar_t, size_t
 
 
-__version__ = "0.14.0"
+__version__ = "0.14.1"
 
 
 hid_init()

--- a/hid.pyx
+++ b/hid.pyx
@@ -68,6 +68,7 @@ def enumerate(int vendor_id=0, int product_id=0):
             'usage_page': c.usage_page,
             'usage': c.usage,
             'interface_number': c.interface_number,
+            'bus_type': c.bus_type,
         })
         c = c.next
     hid_free_enumeration(info)


### PR DESCRIPTION
bus_type field is available in the C API side but not exposed in python.