### PR TITLE
Fix impropper hid_bus_type declaration

### DIFF
--- a/chid.pxd
+++ b/chid.pxd
@@ -1,10 +1,10 @@
 from libc.stddef cimport wchar_t, size_t
 
-cdef extern from "hidapi.h":
+cdef extern from "<hidapi.h>":
     ctypedef struct hid_device:
         pass
 
-    cdef enum hid_bus_type:
+    ctypedef enum hid_bus_type:
         HID_API_BUS_UNKNOWN = 0x00,
         HID_API_BUS_USB = 0x01,
         HID_API_BUS_BLUETOOTH = 0x02,

--- a/hid.pyx
+++ b/hid.pyx
@@ -11,10 +11,10 @@ __version__ = "0.14.0"
 hid_init()
 
 
-cdef extern from "ctype.h":
+cdef extern from "<ctype.h>":
     int wcslen(wchar_t*)
 
-cdef extern from "stdlib.h":
+cdef extern from "<stdlib.h>":
     void free(void* ptr)
     void* malloc(size_t size)
 


### PR DESCRIPTION
- To match the original declaration in HIDAPI upstream and avoid compilation errors with newer gcc;
- Include all "system" headers with '<>'; to be explicit that those don't belong to this project/module;