### PR TITLE
update pyproject and fix readme ref

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,16 @@
+[tool.poetry]
+name = "hidapi"
+version = "0.14.0"
+description = "A Cython interface to the hidapi from https://github.com/libusb/hidapi"
+authors = ["Pavol Rusnak <pavol@rusnak.io>"]
+readme = "README.rst"
+
+[tool.poetry.dependencies]
+python = "^3.12"
+cython = "^3.0.10"
+twine = "^5.1.1"
+setuptools = "^71.1.0"
+
 [build-system]
 requires = ["setuptools", "Cython"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
seeing some readme.md ref issue with 0.14.0.post1 rel, thus updating pyproject.toml to fix the ref

```
 FileNotFoundError: [Errno 2] No such file or directory:
'/private/tmp/keepkey-agent--hidapi-20240723-10954-cn1m1k/hidapi-0.14.0.post1/README.md'
```

- https://github.com/trezor/cython-hidapi/issues/176
- https://github.com/Homebrew/homebrew-core/pull/178205
