### PR TITLE
Feature: add get_report_descriptor wrapper

### DIFF
--- a/chid.pxd
+++ b/chid.pxd
@@ -37,6 +37,7 @@ cdef extern from "<hidapi.h>":
     int hid_read(hid_device* device, unsigned char* data, int max_length) nogil
     int hid_read_timeout(hid_device* device, unsigned char* data, int max_length, int milliseconds) nogil
     int hid_set_nonblocking(hid_device* device, int value)
+    int hid_get_report_descriptor(hid_device* device, unsigned char *data, int length) nogil
     int hid_send_feature_report(hid_device* device, unsigned char *data, int length) nogil
     int hid_get_feature_report(hid_device* device, unsigned char *data, int length) nogil
     int hid_get_input_report(hid_device* device, unsigned char *data, int length) nogil

--- a/hid.pyx
+++ b/hid.pyx
@@ -332,12 +332,13 @@ cdef class device:
 
     def get_report_descriptor(self, int max_length=4096):
         """Return the report descriptor up to max_length bytes.
+        If max_length is bigger than the actual descriptor, the full descriptor will be returned.
 
         :param max_length: Maximum number of bytes to read, must be positive
         :type max_length: int
 
         :return:
-        :rtype: list[int]
+        :rtype: List[int]
         :raises ValueError: If connection is not opened.
         :raises IOError: If read error
         """

--- a/hid.pyx
+++ b/hid.pyx
@@ -330,6 +330,37 @@ cdef class device:
             result = hid_send_feature_report(c_hid, cbuff, c_buff_len)
         return result
 
+    def get_report_descriptor(self, int max_length=4096):
+        """Return the report descriptor up to max_length bytes.
+
+        :param max_length: Maximum number of bytes to read, must be positive
+        :type max_length: int
+
+        :return:
+        :rtype: list[int]
+        :raises ValueError: If connection is not opened.
+        :raises IOError: If read error
+        """
+        if self._c_hid == NULL:
+            raise ValueError('not open')
+
+        cdef unsigned char* cbuff
+        cdef size_t c_descriptor_length = max(1, max_length)
+        cdef hid_device * c_hid = self._c_hid
+        cdef int n
+        result = []
+        try:
+            cbuff = <unsigned char *>malloc(max_length)
+            with nogil:
+                n = hid_get_report_descriptor(c_hid, cbuff, c_descriptor_length)
+            if n < 0:
+                raise IOError('read error')
+            for i in range(n):
+                result.append(cbuff[i])
+        finally:
+            free(cbuff)
+        return result
+
     def get_feature_report(self, int report_num, int max_length):
         """Receive feature report.
 


### PR DESCRIPTION
Added wrapper for `get_report_descriptor` function.

Quite straightforward I think.

Requested by https://github.com/trezor/cython-hidapi/issues/165