### PR TITLE
Remove max_length parameter from get_report_descriptor

### DIFF
--- a/hid.pyx
+++ b/hid.pyx
@@ -330,12 +330,8 @@ cdef class device:
             result = hid_send_feature_report(c_hid, cbuff, c_buff_len)
         return result
 
-    def get_report_descriptor(self, int max_length=4096):
-        """Return the report descriptor up to max_length bytes.
-        If max_length is bigger than the actual descriptor, the full descriptor will be returned.
-
-        :param max_length: Maximum number of bytes to read, must be positive
-        :type max_length: int
+    def get_report_descriptor(self):
+        """Return the report descriptor of the device.
 
         :return:
         :rtype: List[int]
@@ -346,12 +342,12 @@ cdef class device:
             raise ValueError('not open')
 
         cdef unsigned char* cbuff
-        cdef size_t c_descriptor_length = max(1, max_length)
+        cdef size_t c_descriptor_length = 4096
         cdef hid_device * c_hid = self._c_hid
         cdef int n
         result = []
         try:
-            cbuff = <unsigned char *>malloc(max_length)
+            cbuff = <unsigned char *>malloc(c_descriptor_length)
             with nogil:
                 n = hid_get_report_descriptor(c_hid, cbuff, c_descriptor_length)
             if n < 0:

--- a/try.py
+++ b/try.py
@@ -21,6 +21,7 @@ try:
     print("Manufacturer: %s" % h.get_manufacturer_string())
     print("Product: %s" % h.get_product_string())
     print("Serial No: %s" % h.get_serial_number_string())
+    print("Report descriptor: %s" % h.get_report_descriptor())
 
     # enable non-blocking mode
     h.set_nonblocking(1)


### PR DESCRIPTION
Removed `max_length` parameter from `get_report_descriptor` method as per discussion in the last [PR](https://github.com/trezor/cython-hidapi/pull/186).