### PR TITLE
Optimize get_report_descriptor

### DIFF
--- a/chid.pxd
+++ b/chid.pxd
@@ -1,6 +1,8 @@
 from libc.stddef cimport wchar_t, size_t
 
 cdef extern from "<hidapi.h>":
+    const int HID_API_MAX_REPORT_DESCRIPTOR_SIZE
+
     ctypedef struct hid_device:
         pass
 


### PR DESCRIPTION
- use HID_API_MAX_REPORT_DESCRIPTOR_SIZE from hidapi.h
- avoid dynamic memory allocation (use stack variable)
- replace list.append with direct list creation from memory view