### PR TITLE
avoid generating spurious python3-pkg-resources dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -269,5 +269,5 @@ setup(
         "Programming Language :: Python :: 3.9",
     ],
     ext_modules=cythonize(modules, language_level=3),
-    install_requires=["setuptools>=19.0"],
+    setup_requires=["setuptools>=19.0"],
 )


### PR DESCRIPTION
Hi,

This is Debian bug https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1083645
or issue #187 here