### PR TITLE
Add Windows ARM64 wheels

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -29,7 +29,7 @@ jobs:
         uses: pypa/cibuildwheel@v3.3.0
         env:
           CIBW_BUILD: "cp3*-*"
-          CIBW_ARCHS_WINDOWS: "auto"
+          CIBW_ARCHS_WINDOWS: "AMD64 ARM64 x86"
           CIBW_ARCHS_MACOS: "x86_64 arm64"
           CIBW_ARCHS_LINUX: "x86_64 i686 aarch64"
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014


### PR DESCRIPTION
Tested the wheel from GitHub workflow artifacts and it worked on a Snapdragon X1P CPU (HP Omnibook 14 X fe1)