### PR TITLE
Added -std=c99, to setup linux compile arguments

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -144,6 +144,7 @@ def hid_from_embedded_hidapi():
                         "hid",
                         sources=["hid.pyx", hidapi_src("libusb")],
                         include_dirs=[embedded_hidapi_include],
+                        extra_compile_args=["-std=c99"],
                     ),
                     libusb_pkgconfig,
                 )


### PR DESCRIPTION
Fix to error during compilation on CentOS 7.9.2009:

```
cython-hidapi/hidapi/libusb/hid.c:453:3: error: ‘for’ loop initial declarations are only allowed in C99 mode
   for (uint8_t i = 1; i < num_ports; i++) {
   ^
/home/ucn/online/scmfe/cython-hidapi/hidapi/libusb/hid.c:453:3: note: use option -std=c99 or -std=gnu99 to compile your code
error: command 'gcc' failed with exit status 1
```

